### PR TITLE
Support Standard and Legacy SQL queries

### DIFF
--- a/bigquery/.gitignore
+++ b/bigquery/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea
+/bigquery.iml

--- a/bigquery/project.clj
+++ b/bigquery/project.clj
@@ -1,11 +1,11 @@
-(defproject gclouj/bigquery "0.2.5.2"
+(defproject gclouj/bigquery "0.2.6.0"
   :description "Google Cloud BigQuery"
   :url "https://github.com/pingles/gclouj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.google.cloud/gcloud-java-bigquery "0.2.5"]
-                 [clj-time "0.11.0"]]
+                 [com.google.cloud/gcloud-java-bigquery "0.2.8" :exclusions [io.netty/netty-codec-http2 io.grpc/grpc-core]]
+                 [clj-time "0.14.0"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}})

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.idea/
+/storage.iml

--- a/storage/project.clj
+++ b/storage/project.clj
@@ -1,11 +1,11 @@
-(defproject gclouj/storage "0.2.5"
+(defproject gclouj/storage "0.2.6"
   :description "Google Cloud Storage"
   :url "https://github.com/pingles/gclouj"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.google.cloud/gcloud-java-storage "0.2.5"]
-                 [clj-time "0.11.0"]]
+                 [com.google.cloud/gcloud-java-storage "0.2.8" :exclusions [io.netty/netty-codec-http2 io.grpc/grpc-core]]
+                 [clj-time "0.14.0"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}})


### PR DESCRIPTION
This extends the `query-job` function to support use-legacy-sql? which when set to true/nil will result in the query being run as a Legacy SQL query, and when set to false will result in the query being run as a Standard SQL query.

This matches the behaviour of the underlying Java library.